### PR TITLE
build: Use pulseaudio version from meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,15 +16,17 @@ check_dep = dependency('check', version : '>= 0.9.4', required : true)
 dbus_dep = dependency('dbus-1', version : '>= 1.2', required : true)
 pulsecore_dep = dependency('pulsecore', version : '>= 14.2', required : true)
 
-pa_version_str = meson.project_version()
+pa_version_str = pulsecore_dep.version()
 # For tarballs, the first split will do nothing, but for builds in git, we
 # split out suffixes when there are commits since the last tag
 # (e.g.: v11.99.1-3-gad14bdb24 -> v11.99.1)
 version_split = pa_version_str.split('-')[0].split('.')
 pa_version_major = version_split[0].split('v')[0]
 pa_version_minor = version_split[1]
-pa_version_module = version_split[2].split('+')[0]
 pa_version_major_minor = pa_version_major + '.' + pa_version_minor
+project_version_str = meson.project_version()
+project_version_split = project_version_str.split('-')[0].split('.')
+pa_version_module = project_version_split[2].split('+')[0]
 
 pa_c_args = ['-DHAVE_CONFIG_H', '-DPULSEAUDIO_VERSION=' + pa_version_major]
 

--- a/rpm/pulseaudio-modules-nemo.changes
+++ b/rpm/pulseaudio-modules-nemo.changes
@@ -13,7 +13,7 @@
 - Package 2.1.0 from the new upstream at
   https://github.com/nemomobile/pulseaudio-modules-nemo
 
-* Thu Sep 4 2012 Tanu Kaskinen <tanu.kaskinen@jollamobile.com> - 0.9.19.0.11
+* Tue Sep 4 2012 Tanu Kaskinen <tanu.kaskinen@jollamobile.com> - 0.9.19.0.11
 - Fixes NEMO#326: cmtspeech: Change the retry interval for opening
   /dev/cmt_speech from 0.5 seconds to 60 seconds.
 - Removed a duplicate patch.
@@ -62,16 +62,16 @@
 - Buffer change signal sent to old_alsa_sink only when needed.
 - Added 1 second sleepon cmtspeech disconnect to give busytone after call.
 
-* Thu Oct 26 2010 Jouni Peltonen <jouni.peltonen@cybercom.com> - 0.9.21.0.20100915
+* Tue Oct 26 2010 Jouni Peltonen <jouni.peltonen@cybercom.com> - 0.9.21.0.20100915
 - Cmtspeech module patch changed to include alsa_sink_old primary and alternative
   buffer switching. Part of the fix for BMC#8423, BMC#8428 and BMC#8605.
 
-* Tue Oct 14 2010 Sami Sirkia <sami.sirkia@cybercom.com> - 0.9.21.0.20100915
+* Thu Oct 14 2010 Sami Sirkia <sami.sirkia@cybercom.com> - 0.9.21.0.20100915
 - Unnecessary build requirements removed.
 - Requirement for libpulse-browse causes pulseaudio-modules-meego to fail,
   since it is no longer available.
 
-* Tue Oct 6 2010 Sami Sirkia <sami.sirkia@cybercom.com> - 0.9.21.0.20100915
+* Wed Oct 6 2010 Sami Sirkia <sami.sirkia@cybercom.com> - 0.9.21.0.20100915
 - Part of the solution for Bug 8039: "Current N900 telephony audio 
   implementation does not live up to audio standards required 
   by 3GPP for handsets on networks"

--- a/rpm/pulseaudio-modules-nemo.spec
+++ b/rpm/pulseaudio-modules-nemo.spec
@@ -116,44 +116,34 @@ echo "%{moduleversion}" > .tarball-version
 %meson_install
 
 %files common
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/libmeego-common.so
+%{_libdir}/pulse-*/modules/libmeego-common.so
 %license COPYING
 
 %files music
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-music.so
+%{_libdir}/pulse-*/modules/module-meego-music.so
 
 %files record
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-record.so
+%{_libdir}/pulse-*/modules/module-meego-record.so
 
 %files voice
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-voice.so
+%{_libdir}/pulse-*/modules/module-meego-voice.so
 
 %files mainvolume
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-mainvolume.so
+%{_libdir}/pulse-*/modules/module-meego-mainvolume.so
 
 %files parameters
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-parameters.so
+%{_libdir}/pulse-*/modules/module-meego-parameters.so
 
 %files sidetone
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-sidetone.so
+%{_libdir}/pulse-*/modules/module-meego-sidetone.so
 
 %files test
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-meego-test.so
+%{_libdir}/pulse-*/modules/module-meego-test.so
 
 %files stream-restore
-%defattr(-,root,root,-)
-%{_libdir}/pulse-%{pulsemajorminor}/modules/module-stream-restore-nemo.so
+%{_libdir}/pulse-*/modules/module-stream-restore-nemo.so
 
 %files devel
-%defattr(-,root,root,-)
 %{_prefix}/include/pulsecore/modules/meego/*.h
 %{_prefix}/include/pulsecore/modules/sailfishos/*.h
 %{_libdir}/pkgconfig/*.pc


### PR DESCRIPTION
Makes build easier when updating pulseaudio.
Remove not needed defattr from spec.
Fix some dates in changelog.